### PR TITLE
docs: add news folder and some adverts

### DIFF
--- a/anuncios/2023/20230728-anuncio-de-representantes-oficiais-da-comunidade.md
+++ b/anuncios/2023/20230728-anuncio-de-representantes-oficiais-da-comunidade.md
@@ -1,0 +1,19 @@
+| Representantes oficiais do perifaCode em eventos | | 
+|--| -- |
+| Data de criação| 28/07/2023 |
+| Responsável | William Oliveira (@woliveiras) |
+| Aprovação |  |
+
+---
+
+# Representantes oficiais do perifaCode em eventos
+
+A partir de hoje, temos as pessoas que serão representantes oficiais do perifaCode em eventos como meetups, conferências, etc.
+
+Sempre que alguém quiser convidar o perifaCode para algum evento, devemos conectar com essas pessoas.
+
+## Representantes atuais
+
+- Bruna Santos: [@brunachris31](https://twitter.com/brunachris31)
+- Kamila Oliveira: [@kamilah_santos](https://twitter.com/kamilah_santos)
+- Roberson Miguel: [@biosbug](https://twitter.com/biosbug)

--- a/anuncios/2023/20230728-anuncio-de-representantes-oficiais-da-comunidade.md
+++ b/anuncios/2023/20230728-anuncio-de-representantes-oficiais-da-comunidade.md
@@ -1,8 +1,8 @@
 | Representantes oficiais do perifaCode em eventos | | 
 |--| -- |
 | Data de criação| 28/07/2023 |
-| Responsável | William Oliveira (@woliveiras) |
-| Aprovação |  |
+| Responsável | William Oliveira (@1ilhas) |
+| Aprovação | Luís Ângelo: @luisangelorjr, Roberson Miguel: @biosbug, Bruna Santos: @brunachris31, Glauber Castro: @glauberacastro, Guilherme Vieira: @gitlherme, Kamila Oliveira: @kamilah_santos |
 
 ---
 

--- a/anuncios/2023/20230728-criacao-de-pagina-publica-para-anuncios.md
+++ b/anuncios/2023/20230728-criacao-de-pagina-publica-para-anuncios.md
@@ -1,8 +1,8 @@
 | Criação de página para publicação de anúncios da organização para a comunidade | | 
 |--| -- |
 | Data de criação| 28/07/2023 |
-| Responsável | William Oliveira (@woliveiras) |
-| Aprovação |  |
+| Responsável | William Oliveira (@1ilhas) |
+| Aprovação | Luís Ângelo: @luisangelorjr, Roberson Miguel: @biosbug, Bruna Santos: @brunachris31, Glauber Castro: @glauberacastro, Guilherme Vieira: @gitlherme, Kamila Oliveira: @kamilah_santos |
 
 ---
 

--- a/anuncios/2023/20230728-criacao-de-pagina-publica-para-anuncios.md
+++ b/anuncios/2023/20230728-criacao-de-pagina-publica-para-anuncios.md
@@ -1,0 +1,25 @@
+| Criação de página para publicação de anúncios da organização para a comunidade | | 
+|--| -- |
+| Data de criação| 28/07/2023 |
+| Responsável | William Oliveira (@woliveiras) |
+| Aprovação |  |
+
+---
+
+# Criação de página para publicação de anúncios da organização para a comunidade
+
+A partir de hoje utilizaremos este espaço para publicar as nossas normativas para que toda a comunidade tenha acesso as nossas tomadas de decisão e também possam participar através do review dos pull requests.
+
+## Como tudo vai funcionar
+
+A cada tomada de decisão da comunidade, seja através de reunião geral ou reunião extraordinária, abriremos um pull request com todas as informações sobre essa nova diretriz. Este pull request será aprovado pela própria organização a modo de que tenhamos registro das pessoas que aprovaram a publicação do anúncio.
+
+Com o PR aprovado, vamos compartilhar o link para este documento nas nossas redes sociais (oficial do perifaCode ou pessoal).
+
+Caso aconteça uma tomada de decisão que sobrescreva o que fizemos em um primeiro momento (o que foi registrado), devemos abrir um novo documento e referênciar o documento anterior.
+
+Por exemplo: caso tomemos a decisão de modificar como os anúncios serão feitos para a comunidade, devemos abrir um novo documento e adicionar um link para este aqui.
+
+## O que esperamos com isso
+
+Esperamos que, com este histórico, tenhamos mais transparência sobre nossas tomadas de decisão, o futuro da organização e mais comunicação com a comunidade que apoia o perifaCode.

--- a/anuncios/README.md
+++ b/anuncios/README.md
@@ -1,0 +1,37 @@
+# Anúncios
+
+Todos os anúncios da organização do perifaCode para a comunidade e público geral.
+
+Aqui centralizamos as tomadas de decisão da organização e compartilhamos com todas as pessoas para fomentar o debate público sobre o nosso futuro e buscamos estimular a participação da comunidade no nosso trabalho.
+
+## Como encontrar as informações
+
+Para localizar nossos anúncios, acesse a pasta com o ano em questão (o ano atual ou algum outro momento histórico) e procure pela data + título do anúncio.
+
+Por exemplo:
+
+```
+- 2023
+    - 20230728-criacao-de-pagina-publica-para-anuncios.md
+    - 20230728-anuncio-de-representantes-oficiais-da-comunidade.md
+```
+
+## Como escrever um novo documento
+
+Crie um documento `.md` na pasta do ano atual ou do momento histórico que deseja registrar.
+
+O nome do arquivo deve seguir o padrão `<ANO><MÊS><DIA>-<título-da-pagina>.md`.
+
+O header do arquivo deve possuir a seguinte informação:
+
+```
+| Criação de página para publicação de anúncios da organização para a comunidade | | 
+|--| -- |
+| Data de criação| 28/07/2023 |
+| Responsável | William Oliveira (@woliveiras) |
+| Aprovação |  |
+
+---
+
+## Título do anúncio 
+```


### PR DESCRIPTION
Adicionando a sessão de anúncios da comunidade.

Necessário revisão dos documentos e aprovação da organização para dar sequência nos trabalhos e publicação dos anúncios.